### PR TITLE
Allow discount, email, and shop pay redirect to be dynamically passed in

### DIFF
--- a/server/helpers/app-proxy.js
+++ b/server/helpers/app-proxy.js
@@ -5,7 +5,13 @@ import crypto from "crypto";
     Helper function to build Shopify checkout links
     Learn more: https://help.shopify.com/en/manual/products/details/checkout-link
 */
-export const generatedCheckoutLink = ({ shop, link }) => {
+export const generatedCheckoutLink = ({
+  shop,
+  link,
+  discount,
+  payment,
+  email,
+}) => {
   if (!link) return null;
 
   const { products } = link;
@@ -26,7 +32,12 @@ export const generatedCheckoutLink = ({ shop, link }) => {
     .join(",");
 
   // Build remainder of parameters
-  const urlParameters = generateQueryString(link);
+  const urlParameters = generateQueryString({
+    link,
+    discount,
+    payment,
+    email,
+  });
 
   // Create full url
   let checkoutUrl = shop ? `https://${shop.replace("https://", "")}` : "";
@@ -37,13 +48,13 @@ export const generatedCheckoutLink = ({ shop, link }) => {
 /*
   Generate the url query string, specifically
 */
-export const generateQueryString = (link) => {
+export const generateQueryString = ({ link, email, discount, payment }) => {
   const { customer, order } = link;
   let urlParameters = "";
 
   if (customer && Object.keys(customer).length) {
-    if (customer.email) {
-      urlParameters += `&checkout[email]=${customer.email}`;
+    if (email || customer.email) {
+      urlParameters += `&checkout[email]=${email || customer.email}`;
     }
 
     if (customer.first_name) {
@@ -75,24 +86,24 @@ export const generateQueryString = (link) => {
     }
   }
 
-  if (order && Object.keys(order).length) {
-    if (order.discountCode) {
-      urlParameters += `&discount=${order.discountCode}`;
+  if (discount || (order && Object.keys(order).length)) {
+    if (discount || order?.discountCode) {
+      urlParameters += `&discount=${discount || order.discountCode}`;
     }
 
-    if (order.note) {
+    if (order?.note) {
       urlParameters += `&note=${encodeURIComponent(order.note)}`;
     }
 
-    if (order.ref) {
+    if (order?.ref) {
       urlParameters += `&ref=${encodeURIComponent(order.ref)}`;
     }
 
-    if (order.useShopPay) {
-      urlParameters += `&payment=shop_pay`;
+    if (payment || order?.useShopPay) {
+      urlParameters += `&payment=${payment || "shop_pay"}`;
     }
 
-    if (order.attributes && order.attributes.length) {
+    if (order?.attributes && order?.attributes.length) {
       urlParameters += `&${order.attributes
         .map(
           (attribute) =>

--- a/server/routes/proxy/helpers/dynamic.js
+++ b/server/routes/proxy/helpers/dynamic.js
@@ -41,7 +41,7 @@ export const dynamic = async (req, res) => {
         : null,
   };
 
-  const urlQueryString = generateQueryString(formattedLink);
+  const urlQueryString = generateQueryString({ link: formattedLink });
 
   const scripts = getScriptMarkup({
     clearCart,

--- a/server/routes/proxy/helpers/link-alias.js
+++ b/server/routes/proxy/helpers/link-alias.js
@@ -32,16 +32,23 @@ export const linkNotFound = async (req, res) => {
 
 export const link = async (req, res) => {
   const { shop, locale, isMobile, shopifyRequestId } = getHeaders(req);
+  const { email, discount, payment } = req.query;
   const link = req.link;
   const { clearCart, redirectLocation } = getShopLinkSettings(req.shopDoc);
   let scripts = ``;
 
+  // TODO: fix this...
   const hasLineProperties = true;
   const hasSubscription = false;
 
   // We need to use cart api if a link has one of these
   if (hasLineProperties || hasSubscription) {
-    const urlQueryString = generateQueryString(link);
+    const urlQueryString = generateQueryString({
+      link,
+      email,
+      discount,
+      payment,
+    });
 
     scripts = getScriptMarkup({
       clearCart,
@@ -51,7 +58,11 @@ export const link = async (req, res) => {
   } else {
     // Generate checkout link
     const generatedLink = generatedCheckoutLink({
+      shop,
       link,
+      email,
+      discount,
+      payment,
     });
     if (!generatedLink) {
       throw `Checkout link generation failed on ${link} on ${shop}`;


### PR DESCRIPTION
Per discussions with merchants, alias links should allow some basic dynamic fields to override defaults such as discount codes, email, and shop pay redirect.

More in the future but these are the most important.